### PR TITLE
feat: properly set version from goreleaser during builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,9 @@ builds:
     main: ./cmd/git-sweep
     # Binary name
     binary: git-sweep
+    # Add ldflags to inject version info
+    ldflags:
+      - -s -w -X main.version={{.Version}}
 
 archives:
   - format: tar.gz

--- a/cmd/git-sweep/main.go
+++ b/cmd/git-sweep/main.go
@@ -17,6 +17,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is set during build via ldflags
+var version = "dev"
+
 // Global config variable to be used by the command logic
 var appConfig config.Config
 var isDebug bool // Global variable to store debug flag state
@@ -320,12 +323,16 @@ safely (both locally and optionally on the remote).`,
 }
 
 func main() {
-	// Set version dynamically
-	info, ok := debug.ReadBuildInfo()
-	if ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
-		rootCmd.Version = info.Main.Version
+	// Use the version set by ldflags, or fallback to Go's build info
+	if version == "dev" {
+		info, ok := debug.ReadBuildInfo()
+		if ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+			rootCmd.Version = info.Main.Version
+		} else {
+			rootCmd.Version = version // Use the default "dev" value
+		}
 	} else {
-		rootCmd.Version = "dev" // Fallback if no version info found
+		rootCmd.Version = version // Use the version set by goreleaser
 	}
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled build-time injection of version information, ensuring that the application displays more accurate version details.
	- Improved version reporting by using build information when available, with a fallback to a default version for development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->